### PR TITLE
fix: enable Renovate for forked repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":enablePreCommit"
   ],
+  "forkProcessing": "enabled",
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary

- Add `forkProcessing: enabled` to renovate.json
- Renovate skips forked repositories by default

## Reference

- [Renovate docs: forkProcessing](https://docs.renovatebot.com/configuration-options/#forkprocessing)